### PR TITLE
Add the capability to build and run from a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:16
+
+WORKDIR /usr/src/app
+
+COPY . .
+
+EXPOSE 8001
+
+CMD [ "node", "server.js" ]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+server:
+	./server.js
+
+check-docker:
+	docker info > /dev/null 2>&1
+
+build-docker-image: check-docker
+	docker build -t riscv/landscape .
+
+run-server-on-docker: build-docker-image
+	docker run -ti --rm -p 8001:8001 riscv/landscape
+
+clean:
+	docker rmi -f riscv/landscape


### PR DESCRIPTION
This commit adds the capability to build and run the RISC-V Landscape from within a container.

Signed-off-by: Rafael Sene <rafael@riscv.org>


