### PR TITLE
Add BayLibre to "Services", update descriptions

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -292,7 +292,10 @@ landscape:
             name: BayLibre Inc. (member)
             homepage_url: https://baylibre.com/
             logo: baylibre_inc.svg
-            description: BayLibre is the experienced High Tech company that brings your Android and Embedded Linux to the market.
+            description: >-
+              Baylibre is the experienced software development consultancy that
+              brings to life Linux, Zephyr, Android, Yocto and other Open Source
+              software on your RISC-V platforms.
             crunchbase: https://www.crunchbase.com/organization/baylibre
             twitter: https://twitter.com/BayLibre
             extra:
@@ -3676,6 +3679,18 @@ landscape:
             homepage_url: https://www.ashling.com/services-compilers/
             logo: ashling.svg
             crunchbase: https://www.crunchbase.com/organization/ashling-microsystems
+          - item:
+            name: BayLibre Inc.
+            homepage_url: https://baylibre.com/
+            logo: baylibre_inc.svg
+            description: >-
+              Baylibre is the experienced software development consultancy that
+              brings to life Linux, Zephyr, Android, Yocto and other Open Source
+              software on your RISC-V platforms.
+            crunchbase: https://www.crunchbase.com/organization/baylibre
+            twitter: https://twitter.com/BayLibre
+            extra:
+              linkedin_url: https://www.linkedin.com/company/baylibre
           - item:
             name: Cloud-V
             description: >-


### PR DESCRIPTION
BayLibre is currently listed only in the Members category. We'd like to be included under the "Services" list as well.

I've also added a new description after internal feedback (now used in both sections).

I've removed the parts of the checklist below that don't seem relevant (company rather than a project).

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [X] Have you verified that the Crunchbase data for your organization (including headquarters and LinkedIn) is correct?
* [ ] ~5 minutes after opening the pull request, there will be a link to preview the entry on the staging server. Have you confirmed that it looks good?
